### PR TITLE
Use CORS proxy for Legistar events

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -824,7 +824,10 @@
             if (!list) return;
 
             try {
-                const res = await fetch('https://webapi.legistar.com/v1/nashville/Events?$top=20&$orderby=EventDate');
+                // Use a simple CORS proxy so the Legistar API can be accessed from the browser
+                const url = 'https://cors.isomorphic-git.org/https://webapi.legistar.com/v1/nashville/Events?$top=20&$orderby=EventDate';
+                const res = await fetch(url);
+                if (!res.ok) throw new Error(`Request failed: ${res.status}`);
                 const events = await res.json();
                 const upcoming = events
                     .filter(ev => new Date(ev.EventDate) >= new Date())


### PR DESCRIPTION
## Summary
- ensure Legistar events load by fetching through a simple CORS proxy

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68912e967e748332b0d808290373f039