### PR TITLE
Use CORS proxy for Legistar events

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -823,28 +823,78 @@
             const list = document.getElementById('events-list');
             if (!list) return;
 
-            try {
-                const res = await fetch('https://webapi.legistar.com/v1/nashville/Events?$top=20&$orderby=EventDate');
-                const events = await res.json();
-                const upcoming = events
-                    .filter(ev => new Date(ev.EventDate) >= new Date())
-                    .slice(0, 5);
+            const base = 'https://webapi.legistar.com/v1/nashville/Events?$top=20&$orderby=EventDate';
+            const sources = [
+                base,
+                `https://cors.isomorphic-git.org/${base}`,
+                `https://api.allorigins.win/raw?url=${encodeURIComponent(base)}`
+            ];
 
-                if (upcoming.length === 0) {
-                    list.innerHTML = '<li>No upcoming events found.</li>';
+            for (const url of sources) {
+                try {
+                    const res = await fetch(url);
+                    if (!res.ok) continue;
+                    const events = await res.json();
+                    const upcoming = events
+                        .filter(ev => new Date(ev.EventDate) >= new Date())
+                        .slice(0, 6);
+
+                    if (upcoming.length === 0) {
+                        list.innerHTML = '<li>No upcoming events found.</li>';
+                        return;
+                    }
+
+                    list.innerHTML = '';
+                    upcoming.forEach(ev => {
+                        const item = document.createElement('li');
+                        const date = new Date(ev.EventDate).toLocaleString('en-US', { dateStyle: 'medium', timeStyle: 'short' });
+                        item.textContent = `${date} — ${ev.EventBodyName}`;
+                        list.appendChild(item);
+                    });
+                    return; // Successfully loaded events
+                } catch (err) {
+                    console.warn('Failed to fetch events from', url, err);
+                }
+            }
+
+            list.innerHTML = '<li class="error">Unable to load events.</li>';
+        }
+
+        async function fetchLegistarMatters() {
+            const list = document.getElementById('legislation-list');
+            if (!list) return;
+
+            // Ask for the latest 12 matters ordered by agenda date
+            const params = new URLSearchParams({
+                '$top': '12',
+                '$orderby': 'MatterAgendaDate desc'
+            });
+            const url = `https://webapi.legistar.com/v1/nashville/Matters?${params}`;
+
+            try {
+                const res = await fetch(url);
+                if (!res.ok) throw new Error(`Request failed: ${res.status}`);
+                const matters = await res.json();
+
+                if (!matters.length) {
+                    list.innerHTML = '<li>No legislation found.</li>';
                     return;
                 }
 
-                upcoming.forEach(ev => {
+                list.innerHTML = '';
+                matters.forEach(m => {
                     const item = document.createElement('li');
-                    const date = new Date(ev.EventDate).toLocaleString('en-US', { dateStyle: 'medium', timeStyle: 'short' });
-                    item.textContent = `${date} — ${ev.EventBodyName}`;
+                    const date = m.MatterAgendaDate ?
+                        new Date(m.MatterAgendaDate).toLocaleDateString('en-US', { dateStyle: 'medium' }) : '';
+                    const title = m.MatterName || m.MatterTitle || 'Untitled';
+                    item.textContent = `${date} — ${title}`;
                     list.appendChild(item);
                 });
             } catch (err) {
-                list.innerHTML = '<li class="error">Unable to load events.</li>';
-                console.error('Error fetching events:', err);
+                console.warn('Failed to fetch legislation', err);
+                list.innerHTML = '<li class="error">Unable to load legislation.</li>';
             }
         }
 
         fetchLegistarEvents();
+        fetchLegistarMatters();

--- a/index.html
+++ b/index.html
@@ -97,6 +97,12 @@
         <ul id="events-list" class="events-list" aria-live="polite"></ul>
     </section>
 
+    <!-- Latest legislation fetched from Legistar -->
+    <section id="legislation-section" class="intro">
+        <h2>Latest Metro Legislation</h2>
+        <ul id="legislation-list" class="events-list" aria-live="polite"></ul>
+    </section>
+
 
     <!-- Main content -->
     <main class="main-content">


### PR DESCRIPTION
## Summary
- ensure Legistar events load by trying direct and proxied requests
- limit upcoming events list to six items
- show the latest 12 pieces of Metro legislation ordered by agenda date

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68912e967e748332b0d808290373f039